### PR TITLE
Fix some more broken `require` usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,39 +1,56 @@
 {
-	"name": "iei-xlsx",
-	"version": "0.8.1",
-	"author": "sheetjs",
-	"description": "Excel (XLSB/XLSX/XLSM/XLS/XML) and ODS spreadsheet parser and writer",
-	"keywords": [ "excel", "xls", "xlsx", "xlsb", "xlsm", "ods", "office", "spreadsheet" ],
-	"bin": {
-		"xlsx": "./bin/xlsx.njs"
-	},
-	"main": "./xlsx",
-	"dependencies": {
-		"exit-on-epipe":"",
-		"ssf":"~0.8.1",
-		"codepage":"",
-		"cfb":">=0.10.0",
-		"jszip":"2.4.0",
-		"crc-32":"",
-		"adler-32":"",
-		"commander":""
-	},
-	"devDependencies": {
-		"mocha":"",
-		"xlsjs":"",
-		"uglify-js":""
-	},
-	"repository": { "type":"git", "url":"git://github.com/SheetJS/js-xlsx.git" },
-	"scripts": {
-		"pretest": "git submodule init && git submodule update",
-		"test": "make test"
-	},
-	"config": {
-		"blanket": {
-			"pattern": "xlsx.js"
-		}
-	},
-	"bugs": { "url": "https://github.com/SheetJS/js-xlsx/issues" },
-	"license": "Apache-2.0",
-	"engines": { "node": ">=0.8" }
+  "name": "iei-xlsx",
+  "version": "0.8.1",
+  "author": "sheetjs",
+  "description": "Excel (XLSB/XLSX/XLSM/XLS/XML) and ODS spreadsheet parser and writer",
+  "keywords": [
+    "excel",
+    "xls",
+    "xlsx",
+    "xlsb",
+    "xlsm",
+    "ods",
+    "office",
+    "spreadsheet"
+  ],
+  "bin": {
+    "xlsx": "./bin/xlsx.njs"
+  },
+  "main": "./xlsx",
+  "dependencies": {
+    "adler-32": "",
+    "cfb": ">=0.10.0",
+    "codepage": "",
+    "commander": "",
+    "crc-32": "",
+    "crypto": "0.0.3",
+    "exit-on-epipe": "",
+    "jszip": "2.4.0",
+    "ssf": "~0.8.1"
+  },
+  "devDependencies": {
+    "mocha": "",
+    "xlsjs": "",
+    "uglify-js": ""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/SheetJS/js-xlsx.git"
+  },
+  "scripts": {
+    "pretest": "git submodule init && git submodule update",
+    "test": "make test"
+  },
+  "config": {
+    "blanket": {
+      "pattern": "xlsx.js"
+    }
+  },
+  "bugs": {
+    "url": "https://github.com/SheetJS/js-xlsx/issues"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=0.8"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iei-xlsx",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": "sheetjs",
   "description": "Excel (XLSB/XLSX/XLSM/XLS/XML) and ODS spreadsheet parser and writer",
   "keywords": [

--- a/xlsx.js
+++ b/xlsx.js
@@ -1761,12 +1761,7 @@ function shift_range_xls(cell, range) {
 
 var OFFCRYPTO = {};
 var make_offcrypto = function(O, _crypto) {
-	var crypto;
-	if(typeof _crypto !== 'undefined') crypto = _crypto;
-	else if(typeof require !== 'undefined') {
-		try { crypto = require('cry'+'pto'); }
-		catch(e) { crypto = null; }
-	}
+	var crypto = require('crypto');
 
 	O.rc4 = function(key, data) {
 		var S = new Array(256);
@@ -11073,13 +11068,6 @@ var XLSRecordEnum = {
 	0x0000: {}
 };
 
-
-/* Helper function to call out to ODS parser */
-function parse_ods(zip, opts) {
-	if(typeof module !== "undefined" && typeof require !== 'undefined' && typeof ODS === 'undefined') ODS = require('./od' + 's');
-	if(typeof ODS === 'undefined' || !ODS.parse_ods) throw new Error("Unsupported ODS");
-	return ODS.parse_ods(zip, opts);
-}
 function fix_opts_func(defaults) {
 	return function fix_opts(opts) {
 		for(var i = 0; i != defaults.length; ++i) {


### PR DESCRIPTION
* drop ODS support, we don't need to read OpenDocument spreadsheets
* use `crypto` from npm (as opposed to magic string-appending runtime)